### PR TITLE
Add configurable chunking GUI

### DIFF
--- a/src/config_gui.py
+++ b/src/config_gui.py
@@ -1,0 +1,96 @@
+import customtkinter as ctk
+from tkinter import messagebox
+
+class ChunkConfigDialog(ctk.CTkToplevel):
+    """Simple configuration dialog for chunk settings."""
+
+    def __init__(self, master, doc_length: int):
+        super().__init__(master)
+        self.title("Chunk Einstellungen")
+        self.resizable(False, False)
+        self.doc_length = doc_length
+        self.result = None
+
+        self.chunk_var = ctk.StringVar(value="5000")
+        self.mode_var = ctk.StringVar(value="all")
+        self.start_var = ctk.StringVar(value="1")
+        self.end_var = ctk.StringVar(value=str(doc_length))
+
+        self._build_ui()
+
+    def _build_ui(self):
+        info = ctk.CTkLabel(self, text=f"Gesamtlänge des Dokuments: {self.doc_length:,} Zeichen")
+        info.pack(padx=20, pady=(10, 5))
+
+        size_frame = ctk.CTkFrame(self)
+        size_frame.pack(fill="x", padx=20, pady=5)
+        ctk.CTkLabel(size_frame, text="Chunk-Größe in Zeichen:").pack(side="left")
+        self.size_entry = ctk.CTkEntry(size_frame, textvariable=self.chunk_var, width=80)
+        self.size_entry.pack(side="right")
+
+        mode_frame = ctk.CTkFrame(self)
+        mode_frame.pack(fill="x", padx=20, pady=(10, 5))
+        ctk.CTkLabel(mode_frame, text="Zu verarbeitender Bereich:").pack(anchor="w")
+        rb_all = ctk.CTkRadioButton(mode_frame, text="Gesamtes Dokument", variable=self.mode_var, value="all", command=self._toggle_range)
+        rb_all.pack(anchor="w")
+        rb_range = ctk.CTkRadioButton(mode_frame, text="Spezifischer Bereich", variable=self.mode_var, value="range", command=self._toggle_range)
+        rb_range.pack(anchor="w")
+
+        range_frame = ctk.CTkFrame(self)
+        range_frame.pack(fill="x", padx=20, pady=(5, 5))
+        ctk.CTkLabel(range_frame, text="Start-Zeichen:").grid(row=0, column=0, padx=5, pady=2)
+        self.start_entry = ctk.CTkEntry(range_frame, textvariable=self.start_var, width=80)
+        self.start_entry.grid(row=0, column=1, padx=5, pady=2)
+        ctk.CTkLabel(range_frame, text="End-Zeichen:").grid(row=1, column=0, padx=5, pady=2)
+        self.end_entry = ctk.CTkEntry(range_frame, textvariable=self.end_var, width=80)
+        self.end_entry.grid(row=1, column=1, padx=5, pady=2)
+
+        self._range_widgets = (self.start_entry, self.end_entry)
+        self._toggle_range()
+
+        start_btn = ctk.CTkButton(self, text="Start", command=self._on_start)
+        start_btn.pack(pady=(10, 10))
+
+        self.bind("<Return>", lambda _e: self._on_start())
+
+    def _toggle_range(self):
+        state = "normal" if self.mode_var.get() == "range" else "disabled"
+        for widget in self._range_widgets:
+            widget.configure(state=state)
+
+    def _on_start(self):
+        try:
+            chunk_size = int(self.chunk_var.get())
+        except ValueError:
+            messagebox.showerror("Fehler", "Chunk-Größe muss eine Zahl sein.")
+            return
+        if chunk_size < 500 or chunk_size > 50000:
+            messagebox.showerror("Fehler", "Chunk-Größe muss zwischen 500 und 50000 liegen.")
+            return
+
+        if self.mode_var.get() == "range":
+            try:
+                start = int(self.start_var.get())
+                end = int(self.end_var.get())
+            except ValueError:
+                messagebox.showerror("Fehler", "Start und Ende müssen Ganzzahlen sein.")
+                return
+            if not (1 <= start < end <= self.doc_length):
+                messagebox.showerror("Fehler", "Ungültiger Bereich angegeben.")
+                return
+        else:
+            start = 1
+            end = self.doc_length
+
+        self.result = {
+            "chunk_size": chunk_size,
+            "start": start - 1,
+            "end": end,
+            "mode": self.mode_var.get(),
+        }
+        self.destroy()
+
+    def show(self):
+        self.grab_set()
+        self.wait_window()
+        return self.result

--- a/src/gui.py
+++ b/src/gui.py
@@ -1,12 +1,14 @@
 import customtkinter as ctk
 from tkinterdnd2 import DND_FILES, TkinterDnD
+from tkinter import messagebox
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 import threading
 from .text_chunker import TextChunker
 from .file_handler import FileHandler
 from .logger import setup_logger
+from .config_gui import ChunkConfigDialog
 
 logger = setup_logger("gui")
 
@@ -172,34 +174,45 @@ class ChunkerGUI:
             self.drop_label.configure(text="📁 Dateien hier hineinziehen\noder klicken zum Auswählen")
     
     def _process_files(self):
-        """Verarbeitet alle geladenen Dateien in einem separaten Thread."""
+        """Startet die Verarbeitung nach Konfiguration durch den Benutzer."""
+        if not self.loaded_files:
+            return
+
+        # Länge der ersten Datei ermitteln um sie im Dialog anzuzeigen
+        sample_content = self.file_handler.read_file(self.loaded_files[0])
+        if sample_content is None:
+            messagebox.showerror("Fehler", "Datei konnte nicht gelesen werden.")
+            return
+
+        dialog = ChunkConfigDialog(self.root, len(sample_content))
+        config = dialog.show()
+        if not config:
+            self._update_ui_state()
+            return
+
         self.process_button.configure(state="disabled")
         self.clear_button.configure(state="disabled")
-        
-        # Verarbeitung in separatem Thread
-        thread = threading.Thread(target=self._process_files_thread)
+
+        thread = threading.Thread(target=self._process_files_thread, args=(config,))
         thread.start()
-    
-    def _process_files_thread(self):
+
+    def _process_files_thread(self, config: dict):
         """Thread-Funktion für die Dateiverarbeitung."""
         total_files = len(self.loaded_files)
         
         for i, file_path in enumerate(self.loaded_files):
-            # Progress Update
             progress = (i / total_files)
             self.progress_bar.set(progress)
             self.status_label.configure(text=f"Verarbeite: {os.path.basename(file_path)}")
-            
-            # Datei verarbeiten
+
             content = self.file_handler.read_file(file_path)
             if content:
-                # Optional: Sprecher formatieren
-                formatted_content = self.text_chunker.format_with_speakers(content)
-                
-                # In Chunks aufteilen
+                selection = content[config["start"]:config["end"]]
+                formatted_content = self.text_chunker.format_with_speakers(selection)
+
+                self.text_chunker.max_chunk_size = config["chunk_size"]
                 chunks = self.text_chunker.split_text(formatted_content)
-                
-                # Chunks speichern
+
                 self.file_handler.save_chunks(chunks, os.path.basename(file_path))
             
             logger.info(f"Datei verarbeitet: {file_path}")

--- a/src/text_chunker.py
+++ b/src/text_chunker.py
@@ -5,9 +5,15 @@ from .logger import setup_logger
 logger = setup_logger("text_chunker")
 
 class TextChunker:
-    """
-    Klasse zum Aufteilen von Texten in Chunks mit maximaler Zeichenlänge.
-    """
+    """Zerlegt Texte in einzelne Teile (Chunks)."""
+
+    # Der bisherige Ablauf:
+    # 1. Text wird zeilenweise eingelesen.
+    # 2. Jede Zeile wird, falls nötig, an Wortgrenzen in den aktuellen
+    #    Chunk eingefügt.
+    # 3. Überschreitet eine Zeile die maximale Chunk-Größe, wird sie
+    #    selbst an Wortgrenzen aufgeteilt.
+    # 4. Fertige Chunks werden in einer Liste gesammelt und zurückgegeben.
     
     def __init__(self, max_chunk_size: int = 5000):
         """
@@ -16,6 +22,8 @@ class TextChunker:
         Args:
             max_chunk_size: Maximale Anzahl von Zeichen pro Chunk
         """
+        # Standardmäßig ist die Chunk-Größe fest auf 5000 Zeichen gesetzt.
+        # Dieser Wert wird nun über die neue GUI dynamisch angepasst.
         self.max_chunk_size = max_chunk_size
         logger.info(f"TextChunker initialisiert mit max_chunk_size={max_chunk_size}")
     


### PR DESCRIPTION
## Summary
- document existing chunking flow
- add `ChunkConfigDialog` for user settings
- allow configuration from GUI before processing
- adjust TextChunker comments to note new dynamic chunk size

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6878d128e930832292fae07cce244f94